### PR TITLE
fix: 1차 QA 리스트업 피드백 (커뮤니티) 

### DIFF
--- a/apps/web/src/components/common/comment/comment.tsx
+++ b/apps/web/src/components/common/comment/comment.tsx
@@ -8,19 +8,19 @@ import CommentHead from './commentHead';
 
 interface CommentProps {
   id: string;
-  category?: 'magazine' | 'paparazzi' | 'partnership';
+  kind?: 'magazine' | 'paparazzi' | 'partnership';
 }
 
-const Comment = ({ id, category = 'magazine' }: CommentProps) => {
+const Comment = ({ id, kind = 'magazine' }: CommentProps) => {
   const { isMobile } = useMedia({ deviceQuery });
-  const { page, orderBy } = useUrlQuery();
+  const { page, orderBy, category } = useUrlQuery();
 
   const { data: comment } = useComment(
     id,
     {
       page,
       orderBy,
-      category,
+      category: kind,
     },
     {
       enabled: !!id,
@@ -46,6 +46,7 @@ const Comment = ({ id, category = 'magazine' }: CommentProps) => {
           <CommentBody
             postId={id}
             comments={comment.data}
+            kind={kind}
             category={category}
           />
           <Pagination
@@ -53,7 +54,7 @@ const Comment = ({ id, category = 'magazine' }: CommentProps) => {
             totalCount={comment.totalCount}
             pageSize={10}
           />
-          <CommentArea postId={id} category={category} />
+          <CommentArea postId={id} kind={kind} category={category} />
         </>
       )}
     </Container>

--- a/apps/web/src/components/common/comment/commentArea.tsx
+++ b/apps/web/src/components/common/comment/commentArea.tsx
@@ -73,7 +73,7 @@ const CommentArea = ({
             isAuthenticated ? '댓글을 남겨보세요.' : '로그인이 필요합니다.'
           }
           minLength={1}
-          maxLength={2000}
+          maxLength={1999}
           disabled={!isAuthenticated}
         />
       </CommentAreaTop>

--- a/apps/web/src/components/common/comment/commentBody.tsx
+++ b/apps/web/src/components/common/comment/commentBody.tsx
@@ -33,19 +33,21 @@ const CommentCard = ({
   isRemoved,
   isLiked,
   children,
+  kind,
   category,
 }: Comment & {
   root?: boolean;
   postId: string;
-  category: 'magazine' | 'paparazzi' | 'partnership';
+  category: string;
+  kind: 'magazine' | 'paparazzi' | 'partnership';
 }) => {
   const { mutate: likeMuate } = useLikeComment({
-    category,
+    category: kind,
     postId,
     commentId: id,
   });
   const { mutate: removeMutate } = useRemoveComment({
-    category,
+    category: kind,
     postId,
     commentId: id,
   });
@@ -53,12 +55,14 @@ const CommentCard = ({
   const [open, setOpen] = React.useState(false);
 
   const handleOpen = React.useCallback(() => {
+    if (modify) setModify(false);
     setOpen((prev) => !prev);
-  }, []);
+  }, [modify]);
 
   const handleModify = React.useCallback(() => {
+    if (open) setOpen(false);
     setModify((prev) => !prev);
-  }, []);
+  }, [open]);
 
   const handleRemove = React.useCallback(() => {
     removeMutate();
@@ -317,6 +321,8 @@ const CommentCard = ({
             postId={postId}
             parentId={id}
             defaultValue={content}
+            kind={kind}
+            onSuccess={handleModify}
             category={category}
             type="edit"
           />
@@ -324,7 +330,13 @@ const CommentCard = ({
       )}
       {open && (
         <Wrapper css={style.cardArea}>
-          <CommentArea postId={postId} parentId={id} category={category} />
+          <CommentArea
+            postId={postId}
+            parentId={id}
+            kind={kind}
+            category={category}
+            onSuccess={handleOpen}
+          />
         </Wrapper>
       )}
       {children && (
@@ -333,8 +345,9 @@ const CommentCard = ({
             <CommentCard
               key={comment.id}
               postId={postId}
-              category={category}
+              kind={kind}
               root={false}
+              category={category}
               {...comment}
             />
           ))}
@@ -347,11 +360,13 @@ const CommentCard = ({
 const CommentBody = ({
   postId,
   comments,
-  category = 'magazine',
+  kind = 'magazine',
+  category,
 }: {
   postId: string;
   comments: Comment[];
-  category?: 'magazine' | 'paparazzi' | 'partnership';
+  kind?: 'magazine' | 'paparazzi' | 'partnership';
+  category: string;
 }) => {
   return (
     <Container display="flex" flexDirection="column">
@@ -365,6 +380,7 @@ const CommentBody = ({
         <CommentCard
           key={comment.id}
           postId={postId}
+          kind={kind}
           category={category}
           {...comment}
         />

--- a/apps/web/src/components/common/comment/commentHead.tsx
+++ b/apps/web/src/components/common/comment/commentHead.tsx
@@ -48,6 +48,7 @@ const CommentHead = ({ totalCount }: CommentHeadProps) => {
               orderBy: 'DESC',
             },
           }}
+          scroll={false}
         >
           <Typography
             fontSize="body-16"
@@ -68,6 +69,7 @@ const CommentHead = ({ totalCount }: CommentHeadProps) => {
               orderBy: 'ASC',
             },
           }}
+          scroll={false}
         >
           <Typography
             fontSize="body-16"

--- a/apps/web/src/components/common/posting/posting.tsx
+++ b/apps/web/src/components/common/posting/posting.tsx
@@ -111,7 +111,7 @@ const CommunityPosting = ({
       id: postId,
     },
     {
-      enabled: session.status !== 'loading',
+      enabled: session.status && session.status !== 'loading',
     }
   );
   const { mutate: likeMuate } = useLikeCommunityPost({

--- a/apps/web/src/components/common/posting/posting.tsx
+++ b/apps/web/src/components/common/posting/posting.tsx
@@ -192,7 +192,7 @@ const CommunityPosting = ({
                     ? '/community/create'
                     : undefined
                 }
-                list={`/community/${subject}`}
+                list={`/community/${subject}?category=${category}`}
               />
               <Wrapper
                 css={css`

--- a/apps/web/src/components/common/posting/posting.tsx
+++ b/apps/web/src/components/common/posting/posting.tsx
@@ -275,7 +275,7 @@ const CommunityPosting = ({
                   </Wrapper.Item>
                 </Button>
               </Wrapper>
-              <Comment id={postId} category={subject} />
+              <Comment id={postId} kind={subject} />
               <Wrapper
                 css={css`
                   width: 100%;

--- a/apps/web/src/components/common/posting/postingBody.tsx
+++ b/apps/web/src/components/common/posting/postingBody.tsx
@@ -1,5 +1,7 @@
-import { Container, Wrapper } from '@supercarmarket/ui';
-import { css } from 'styled-components';
+import '@toast-ui/editor/dist/toastui-editor-viewer.css';
+
+import { Container } from '@supercarmarket/ui';
+import { Viewer } from '@toast-ui/react-editor';
 
 interface PostingBodyProps {
   contentHtml: string;
@@ -8,47 +10,7 @@ interface PostingBodyProps {
 const PostingBody = ({ contentHtml }: PostingBodyProps) => {
   return (
     <Container margin="40px 0">
-      <Wrapper
-        css={css`
-          p {
-            line-height: 160%;
-          }
-          code {
-            color: #c1798b;
-            background-color: #f9f2f4;
-            padding: 2px 3px px;
-            letter-spacing: -0.3px;
-            border-radius: 2px;
-          }
-          hr {
-            border-top: 1px solid #eee;
-            margin: 16px 0;
-          }
-          strong {
-            font-weight: bold;
-          }
-          del {
-            color: #999;
-          }
-          a {
-            color: #1f70de;
-            cursor: pointer;
-            text-decoration: underline;
-          }
-          img {
-            margin: 4px 0 10px;
-            box-sizing: border-box;
-            vertical-align: top;
-            max-width: 100%;
-          }
-        `}
-      >
-        <div
-          dangerouslySetInnerHTML={{
-            __html: contentHtml,
-          }}
-        />
-      </Wrapper>
+      <Viewer initialValue={contentHtml} />
     </Container>
   );
 };

--- a/apps/web/src/components/common/posting/postingBody.tsx
+++ b/apps/web/src/components/common/posting/postingBody.tsx
@@ -1,32 +1,54 @@
-import { Container } from '@supercarmarket/ui';
+import { Container, Wrapper } from '@supercarmarket/ui';
+import { css } from 'styled-components';
 
 interface PostingBodyProps {
   contentHtml: string;
 }
 
-const convertHtml = (html: string) => {
-  const document = new DOMParser().parseFromString(html, 'text/html');
-
-  const images = Array.from(document.querySelectorAll('img'));
-
-  images.forEach((element) => {
-    if (element.width > 261) {
-      element.style.width = '100%';
-      element.style.height = 'auto';
-    }
-  });
-
-  return document.body.innerHTML;
-};
-
 const PostingBody = ({ contentHtml }: PostingBodyProps) => {
   return (
     <Container margin="40px 0">
-      <div
-        dangerouslySetInnerHTML={{
-          __html: convertHtml(contentHtml),
-        }}
-      />
+      <Wrapper
+        css={css`
+          p {
+            line-height: 160%;
+          }
+          code {
+            color: #c1798b;
+            background-color: #f9f2f4;
+            padding: 2px 3px px;
+            letter-spacing: -0.3px;
+            border-radius: 2px;
+          }
+          hr {
+            border-top: 1px solid #eee;
+            margin: 16px 0;
+          }
+          strong {
+            font-weight: bold;
+          }
+          del {
+            color: #999;
+          }
+          a {
+            color: #1f70de;
+            cursor: pointer;
+            text-decoration: underline;
+          }
+          img {
+            margin: 4px 0 10px;
+            box-sizing: border-box;
+            vertical-align: top;
+            max-width: 100%;
+          }
+        `}
+      >
+        <div
+          dangerouslySetInnerHTML={{
+            __html: contentHtml,
+          }}
+        />
+      </Wrapper>
     </Container>
   );
 };

--- a/apps/web/src/components/common/posting/postingHead.tsx
+++ b/apps/web/src/components/common/posting/postingHead.tsx
@@ -216,7 +216,7 @@ const PostingHeadCommunity = ({
             color="greyScale-5"
             lineHeight="120%"
           >
-            {dayjs(created).format('YYYY-MM-DD')}
+            {dayjs(created).format('YYYY.MM.DD HH:MM')}
           </Typography>
         </Wrapper.Left>
         <Wrapper.Right css={style.right}>

--- a/apps/web/src/components/community/communityBestList/communityBestList.tsx
+++ b/apps/web/src/components/community/communityBestList/communityBestList.tsx
@@ -1,20 +1,13 @@
-import { useUrlQuery } from '@supercarmarket/hooks';
-import { Alert, Container, Wrapper } from '@supercarmarket/ui';
+import { CommunityDto } from '@supercarmarket/types/community';
+import { Alert, applyMediaQuery, Container, Wrapper } from '@supercarmarket/ui';
 import { CardSkeleton } from 'components/fallback/loading';
-import useCommunity from 'hooks/queries/community/useCommunity';
+import useHome from 'hooks/queries/useHome';
 import * as React from 'react';
 import { css } from 'styled-components';
 import CommunityCard from '../communityCard';
 
 const CommunityBestList = () => {
-  const { category } = useUrlQuery();
-  const { data, isFetching, isLoading } = useCommunity({
-    category: category || 'report',
-    page: 0,
-    filter: 'popular',
-    searchType: 'title',
-    keyword: null,
-  });
+  const { data, isFetching, isLoading } = useHome<CommunityDto>('community');
 
   if (isFetching || isLoading)
     return <CardSkeleton size={4} variant="column" />;
@@ -25,6 +18,15 @@ const CommunityBestList = () => {
         css={css`
           width: 100%;
           padding-bottom: 52.5px;
+          display: grid;
+          grid-template-columns: 1fr 1fr 1fr 1fr;
+          gap: 20px;
+          ${applyMediaQuery('mobile')} {
+            column-gap: 8px;
+            row-gap: 16px;
+            overflow-x: scroll;
+            padding-bottom: 32px;
+          }
         `}
       >
         {data && data.data.length > 0 ? (

--- a/apps/web/src/components/community/communityCard/communityCard.tsx
+++ b/apps/web/src/components/community/communityCard/communityCard.tsx
@@ -215,7 +215,7 @@ const CommunityCardRow = (props: CommunityCardChildrenProps) => {
               color="greyScale-6"
               lineHeight="150%"
             >
-              {dayjs(created).format('hh:ss')}
+              {dayjs(created).format('hh:mm')}
             </Typography>
             <Typography
               fontSize="body-14"

--- a/apps/web/src/components/community/communityForm/communityEditor.tsx
+++ b/apps/web/src/components/community/communityForm/communityEditor.tsx
@@ -1,15 +1,18 @@
 import '@toast-ui/editor/dist/toastui-editor.css';
+import '@toast-ui/editor/dist/i18n/ko-kr';
 
 import { Editor } from '@toast-ui/react-editor';
+import type { EditorProps } from '@toast-ui/react-editor';
 import * as React from 'react';
 
 interface CommunityEditorProps {
   editor: React.Ref<InstanceType<typeof Editor>>;
+  plugins?: EditorProps['plugins'];
   init?: () => void;
 }
 
 const CommunityEditor = (props: CommunityEditorProps) => {
-  const { editor, init } = props;
+  const { editor, plugins, init } = props;
 
   React.useEffect(() => {
     if (init) init();
@@ -23,13 +26,14 @@ const CommunityEditor = (props: CommunityEditorProps) => {
       height="800px"
       initialEditType="wysiwyg"
       initialValue=" "
-      language="ko"
+      language="ko-KR"
       toolbarItems={[
         ['bold', 'strike'],
         ['hr'],
         ['image', 'link'],
         ['code', 'codeblock'],
       ]}
+      plugins={plugins}
       hideModeSwitch
     />
   );

--- a/apps/web/src/components/community/communityForm/communityEditor.tsx
+++ b/apps/web/src/components/community/communityForm/communityEditor.tsx
@@ -25,9 +25,8 @@ const CommunityEditor = (props: CommunityEditorProps) => {
       initialValue=" "
       language="ko"
       toolbarItems={[
-        ['heading', 'bold', 'italic', 'strike'],
-        ['hr', 'quote'],
-        ['ul', 'ol', 'task', 'indent', 'outdent'],
+        ['bold', 'strike'],
+        ['hr'],
         ['image', 'link'],
         ['code', 'codeblock'],
       ]}

--- a/apps/web/src/components/community/communityForm/communityForm.tsx
+++ b/apps/web/src/components/community/communityForm/communityForm.tsx
@@ -110,7 +110,8 @@ const CommunityForm = (props: CommunityFormProps) => {
   }, [id, initialData.contents]);
 
   const handleEditorHtml = React.useCallback(async () => {
-    const html = editor.current?.getInstance()?.getHTML();
+    const instance = editor.current?.getInstance();
+    const html = instance?.getHTML();
 
     if (!html) {
       throw 'editor contents is require';
@@ -121,6 +122,14 @@ const CommunityForm = (props: CommunityFormProps) => {
     const isImg = img.length > 0;
     const isTempImg = initialData.images && initialData.images.length > 0;
     const thumbnail = img[0]?.src || null;
+    const isContents = Array.from(document.querySelectorAll('p')).some(
+      (element) => element.innerText
+    );
+
+    if (!isContents) {
+      setError('본문에 내용을 작성해주세요.');
+      throw 'contents is require';
+    }
 
     let addImgSrcs = null;
     let deleteImgSrcs = null;
@@ -154,8 +163,6 @@ const CommunityForm = (props: CommunityFormProps) => {
     // * case 2-3 @임시저장 이미지가 존재하고, 내부 에디터에 이미지가 존재하지 않는 경우
 
     if (isTempImg && isInitialize && !isImg) {
-      console.log('check');
-
       deleteImgSrcs = initialData.images;
     }
 

--- a/apps/web/src/components/community/communityForm/communityForm.tsx
+++ b/apps/web/src/components/community/communityForm/communityForm.tsx
@@ -343,23 +343,26 @@ const CommunityForm = (props: CommunityFormProps) => {
 
       if (id)
         queryClient.refetchQueries({
-          queryKey: queries.community.detail(
-            category === 'information' ? 'library' : 'paparazzi',
-            reverseFormatter(category),
-            id
-          ),
+          queryKey: [
+            ...queries.community.all,
+            {
+              subject: category === 'information' ? 'library' : 'paparazzi',
+              category: reverseFormatter(category),
+              id,
+            },
+          ],
         });
 
-      queryClient.invalidateQueries({
+      queryClient.refetchQueries({
         queryKey: [
           ...queries.community.lists(),
-          ...queries.community.query({
-            category,
-            filter: 'null',
-            searchType: 'null',
-            keyword: 'null',
+          {
+            category: reverseFormatter(category),
             page: 0,
-          }),
+            filter: undefined,
+            searchType: undefined,
+            keyword: undefined,
+          },
         ],
       });
 

--- a/apps/web/src/components/community/communityList/communityList.tsx
+++ b/apps/web/src/components/community/communityList/communityList.tsx
@@ -112,7 +112,13 @@ const CommunityList = (props: CommunityListProps) => {
           scroll
           create={status === 'authenticated' ? '/community/create' : undefined}
         />
-        <Pagination pageSize={12} totalCount={1} totalPages={1} />
+        {data && (
+          <Pagination
+            pageSize={20}
+            totalCount={data.totalCount}
+            totalPages={data.totalPages}
+          />
+        )}
       </Wrapper>
       <Wrapper
         css={css`

--- a/apps/web/src/components/community/communityList/communityList.tsx
+++ b/apps/web/src/components/community/communityList/communityList.tsx
@@ -26,13 +26,14 @@ const CommunityList = (props: CommunityListProps) => {
   const { category: iCategory, status } = props;
   const pathname = usePathname();
   const { push } = useRouter();
-  const { variant, category, page, searchType, keyword } = useUrlQuery();
+  const { variant, category, page, searchType, keyword, filter } =
+    useUrlQuery();
 
   const { data, isFetching, isLoading } = useCommunity({
     category: iCategory || category || 'report',
-    filter: null,
-    searchType: searchType ?? null,
-    keyword: keyword ?? null,
+    filter: filter === 'popular' ? filter : undefined,
+    searchType,
+    keyword,
     page,
   });
 

--- a/apps/web/src/components/community/communityList/communityList.tsx
+++ b/apps/web/src/components/community/communityList/communityList.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import {
   Alert,
@@ -15,6 +16,7 @@ import useCommunity from 'hooks/queries/community/useCommunity';
 import { css } from 'styled-components';
 import CommunityCard from '../communityCard';
 import { CardSkeleton } from 'components/fallback/loading';
+import { searchTypeFormatter } from '@supercarmarket/lib';
 
 interface CommunityListProps {
   category?: string;
@@ -24,15 +26,16 @@ interface CommunityListProps {
 
 const CommunityList = (props: CommunityListProps) => {
   const { category: iCategory, status } = props;
+  const [select, setSelect] = React.useState('');
   const pathname = usePathname();
   const { push } = useRouter();
-  const { variant, category, page, searchType, keyword, filter } =
+  const { variant, category, page, keyword, searchType, filter } =
     useUrlQuery();
 
   const { data, isFetching, isLoading } = useCommunity({
     category: iCategory || category || 'report',
     filter: filter === 'popular' ? filter : undefined,
-    searchType,
+    searchType: searchType ? searchType : undefined,
     keyword,
     page,
   });
@@ -140,6 +143,11 @@ const CommunityList = (props: CommunityListProps) => {
           `}
         >
           <FormSelect
+            defaultValues={
+              searchType
+                ? searchTypeFormatter(searchType, { reverse: true })
+                : undefined
+            }
             option={{
               name: 'serachType',
               values: ['제목', '제목 + 본문', '닉네임'],
@@ -147,6 +155,13 @@ const CommunityList = (props: CommunityListProps) => {
             style={{
               width: '100%',
               height: '44px',
+            }}
+            callback={(value) => {
+              if (!value) return;
+              if (value === searchTypeFormatter(select, { reverse: true }))
+                return;
+
+              setSelect(searchTypeFormatter(value));
             }}
           />
         </Wrapper.Item>
@@ -156,7 +171,7 @@ const CommunityList = (props: CommunityListProps) => {
           defaultValue={keyword}
           handleClick={(query) =>
             push(
-              `${pathname}?category=${category}&variant=${variant}&searchType=${searchType}&keyword=${query}`
+              `${pathname}?category=${category}&variant=${variant}&searchType=${select}&keyword=${query}`
             )
           }
           style={{

--- a/apps/web/src/components/home/community/community.tsx
+++ b/apps/web/src/components/home/community/community.tsx
@@ -35,7 +35,7 @@ const Community = () => {
             <CommunityCard key={d.id} variant="column" {...d} />
           ))}
       </Wrapper>
-      <RouterButton href="/community">
+      <RouterButton href="/community/paparazzi?category=report">
         <Typography fontSize="header-16" fontWeight="bold" color="black">
           커뮤니티 더보기
         </Typography>

--- a/apps/web/src/constants/community.ts
+++ b/apps/web/src/constants/community.ts
@@ -5,6 +5,7 @@ interface FormState {
   category: string;
   title: string;
   temporaryStorage?: boolean;
+  tempId?: string;
 }
 
 const community = {

--- a/apps/web/src/hooks/mutations/comment/useAddComment.ts
+++ b/apps/web/src/hooks/mutations/comment/useAddComment.ts
@@ -1,5 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import queries from 'constants/queries';
+import { useMutation } from '@tanstack/react-query';
 import { clientApi } from 'utils/api/fetcher';
 
 export default function useAddComment(
@@ -11,7 +10,6 @@ export default function useAddComment(
   options = {}
 ) {
   const { category, postId, parentId } = query;
-  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (data: any) =>
@@ -24,9 +22,6 @@ export default function useAddComment(
         },
         data,
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries(queries.comment.id(postId));
-    },
     ...options,
   });
 }

--- a/apps/web/src/hooks/mutations/comment/useUpdateComment.ts
+++ b/apps/web/src/hooks/mutations/comment/useUpdateComment.ts
@@ -1,5 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import queries from 'constants/queries';
+import { useMutation } from '@tanstack/react-query';
 import { clientApi } from 'utils/api/fetcher';
 
 export default function useUpdateComment(
@@ -11,7 +10,6 @@ export default function useUpdateComment(
   options = {}
 ) {
   const { category, postId, commentId } = query;
-  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (contents: string) =>
@@ -24,9 +22,6 @@ export default function useUpdateComment(
         },
         data: { contents },
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries(queries.comment.id(postId));
-    },
     ...options,
   });
 }

--- a/apps/web/src/hooks/mutations/community/useLikeCommunityPost.ts
+++ b/apps/web/src/hooks/mutations/community/useLikeCommunityPost.ts
@@ -26,9 +26,14 @@ export default function useLikeCommunityPost(
         },
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries(
-        queries.community.detail(subject, category, id)
-      );
+      queryClient.invalidateQueries([
+        ...queries.community.all,
+        {
+          subject,
+          category,
+          id,
+        },
+      ]);
     },
     useErrorBoundary: true,
     ...options,

--- a/apps/web/src/hooks/queries/community/useCommunity.ts
+++ b/apps/web/src/hooks/queries/community/useCommunity.ts
@@ -7,20 +7,14 @@ import { clientFetcher } from 'utils/api/fetcher';
 export default function useCommunity(
   query: {
     category: string;
-    filter: string | null;
     page: number;
-    searchType: string;
-    keyword: string | null;
+    filter?: string;
+    searchType?: string;
+    keyword?: string;
   },
   options = {}
 ) {
-  const {
-    category = 'report',
-    filter = null,
-    page = 0,
-    searchType,
-    keyword,
-  } = query;
+  const { category = 'report', page = 0, filter, searchType, keyword } = query;
 
   const currentQuery = keyword && {
     searchType,
@@ -28,7 +22,16 @@ export default function useCommunity(
   };
 
   return useQuery<PaginationResponse<CommunityDto[]>>(
-    [...queries.community.lists(), ...queries.community.query(query)],
+    [
+      ...queries.community.lists(),
+      {
+        category,
+        filter,
+        page,
+        searchType,
+        keyword,
+      },
+    ],
     () =>
       clientFetcher('/server/supercar/v1/community', {
         method: 'GET',

--- a/apps/web/src/hooks/queries/community/useCommunity.ts
+++ b/apps/web/src/hooks/queries/community/useCommunity.ts
@@ -28,10 +28,7 @@ export default function useCommunity(
   };
 
   return useQuery<PaginationResponse<CommunityDto[]>>(
-    queries.market.lists([
-      ...queries.community.lists(),
-      ...queries.community.query(query),
-    ]),
+    [...queries.community.lists(), ...queries.community.query(query)],
     () =>
       clientFetcher('/server/supercar/v1/community', {
         method: 'GET',

--- a/apps/web/src/hooks/queries/community/useCommunityPost.ts
+++ b/apps/web/src/hooks/queries/community/useCommunityPost.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import queries from 'constants/queries';
-import { clientFetcher } from 'utils/api/fetcher';
 import type { ServerResponse } from '@supercarmarket/types/base';
 import type { CommunityPostDto } from '@supercarmarket/types/community';
+import { clientFetcher } from '@supercarmarket/lib';
 
 export default function useCommunityPost(
   token: string | null,

--- a/apps/web/src/hooks/queries/community/useCommunityPost.ts
+++ b/apps/web/src/hooks/queries/community/useCommunityPost.ts
@@ -20,7 +20,14 @@ export default function useCommunityPost(
   if (token) headers = { ACCESS_TOKEN: token };
 
   return useQuery<ServerResponse<CommunityPostDto>>(
-    queries.community.detail(subject, category, id),
+    [
+      ...queries.community.all,
+      {
+        subject,
+        category,
+        id,
+      },
+    ],
     () =>
       clientFetcher(`/server/supercar/v1/community/${category}/post-id/${id}`, {
         method: 'GET',

--- a/apps/web/src/hooks/queries/community/useCommunityTemporaryStorage.ts
+++ b/apps/web/src/hooks/queries/community/useCommunityTemporaryStorage.ts
@@ -12,7 +12,12 @@ export default function useCommunityTemporaryStorage(
   options = {}
 ) {
   return useQuery(
-    queries.market.lists([query.category]),
+    [
+      ...queries.community.all,
+      {
+        ...query,
+      },
+    ],
     () =>
       clientFetcher('/supercar/v1/community-temp', {
         method: 'GET',

--- a/apps/web/src/pages/community/[subject]/[category]/[id]/index.tsx
+++ b/apps/web/src/pages/community/[subject]/[category]/[id]/index.tsx
@@ -73,11 +73,22 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   const queryClient = new QueryClient();
   let headers = {};
+  const boardView = req.cookies['boardView'];
 
-  if (session) headers = { ACCESS_TOKEN: session.accessToken };
+  if (boardView) headers = { ...headers, Cookie: `boardView=${boardView}` };
+  if (session) headers = { ...headers, ACCESS_TOKEN: session.accessToken };
 
   queryClient.prefetchQuery(
-    queries.community.detail(subject, category, id),
+    [
+      [
+        ...queries.community.all,
+        {
+          subject,
+          category,
+          id,
+        },
+      ],
+    ],
     () =>
       serverFetcher(
         `${process.env.NEXT_PUBLIC_SERVER_URL}/supercar/v1/community/${category}/post-id/${id}`,

--- a/apps/web/src/pages/community/[subject]/index.tsx
+++ b/apps/web/src/pages/community/[subject]/index.tsx
@@ -15,9 +15,12 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorFallback } from 'components/fallback';
 import { useSession } from 'next-auth/react';
 import HeadSeo from 'components/common/headSeo';
+import { useUrlQuery } from '@supercarmarket/hooks';
+import { formatter } from 'components/community/communityCard/communityCard';
 
 const CommunityCategory: NextPageWithLayout = () => {
   const { status } = useSession();
+  const { category } = useUrlQuery();
 
   return (
     <>
@@ -58,7 +61,7 @@ const CommunityCategory: NextPageWithLayout = () => {
                     align-items: center;
                   `}
                 >
-                  <Title>제보</Title>
+                  <Title>{formatter(category)}</Title>
                   <Tab
                     popular
                     variant

--- a/packages/hooks/useUrlQuery.ts
+++ b/packages/hooks/useUrlQuery.ts
@@ -28,7 +28,7 @@ export default function useUrlQuery() {
     filter: filter ?? 'created_date',
     category: category ?? 'all',
     variant: variant ? variant : 'row',
-    searchType: searchType ? searchType : 'title',
+    searchType: searchType ? searchType : undefined,
     keyword: keyword ?? undefined,
     minDate: minDate ?? undefined,
     maxDate: maxDate ?? undefined,

--- a/packages/lib/formatter.ts
+++ b/packages/lib/formatter.ts
@@ -1,0 +1,16 @@
+export const searchTypeFormatter = (
+  searchType: string,
+  options?: {
+    reverse?: boolean;
+  }
+) => {
+  if (options?.reverse) {
+    if (searchType === 'user') return '닉네임';
+    if (searchType === 'title-contents') return '제목 + 본문';
+    return '제목';
+  }
+
+  if (searchType === '닉네임') return 'user';
+  if (searchType === '제목 + 본문') return 'title-contents';
+  return 'title';
+};

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -5,3 +5,4 @@ export * from './embeds';
 export * from './random';
 export * from './browser/browser.utils';
 export * from './text';
+export * from './formatter';

--- a/packages/ui/components/tab/tab.tsx
+++ b/packages/ui/components/tab/tab.tsx
@@ -140,7 +140,7 @@ const Tab = ({
                     <g clipPath="url(#clip0_268_8692)">
                       <path
                         d="M3 18H21V16H3V18ZM3 13H21V11H3V13ZM3 6V8H21V6H3Z"
-                        fill={isVariantRow ? '#1E1E20' : '#C3C3C7'}
+                        fill={isVariantRow ? '#C3C3C7' : '#1E1E20'}
                       />
                     </g>
                     <defs>
@@ -188,28 +188,28 @@ const Tab = ({
                       y="3"
                       width="8"
                       height="8"
-                      fill={isVariantRow ? '#C3C3C7' : '#1E1E20'}
+                      fill={isVariantRow ? '#1E1E20' : '#C3C3C7'}
                     />
                     <rect
                       x="13"
                       y="3"
                       width="8"
                       height="8"
-                      fill={isVariantRow ? '#C3C3C7' : '#1E1E20'}
+                      fill={isVariantRow ? '#1E1E20' : '#C3C3C7'}
                     />
                     <rect
                       x="13"
                       y="13"
                       width="8"
                       height="8"
-                      fill={isVariantRow ? '#C3C3C7' : '#1E1E20'}
+                      fill={isVariantRow ? '#1E1E20' : '#C3C3C7'}
                     />
                     <rect
                       x="3"
                       y="13"
                       width="8"
                       height="8"
-                      fill={isVariantRow ? '#C3C3C7' : '#1E1E20'}
+                      fill={isVariantRow ? '#1E1E20' : '#C3C3C7'}
                     />
                   </svg>
                 </Wrapper>

--- a/packages/ui/form/formFiles.tsx
+++ b/packages/ui/form/formFiles.tsx
@@ -34,7 +34,7 @@ const FormFile = React.memo(function FormFile({
           fontWeight="regular"
           color="greyScale-6"
           lineHeight="150%"
-        >{`파일 ${index}`}</Typography>
+        >{`파일 ${index + 1}`}</Typography>
         <Typography
           fontSize="body-14"
           fontWeight="regular"


### PR DESCRIPTION
# Pull Request

- [x] Feature
- [x] Fix bug
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary
qa 리스트업 커뮤니티 건의/버그 사항 수정하였습니다.

<img width="1042" alt="스크린샷 2023-03-21 오후 5 11 50" src="https://user-images.githubusercontent.com/66871265/226549537-9b8848c7-ef41-445f-8191-01e7a3f00b45.png">

<img width="1059" alt="스크린샷 2023-03-21 오후 5 11 56" src="https://user-images.githubusercontent.com/66871265/226549580-3e5f71ed-0f81-40bb-a2c3-b71aa1c4fa20.png">


개발하면서 놓쳤던 디테일을 잡았습니다.

qa 리스트업 중 게시글 조회수 중복카운팅 문제가 있었습니다.

이 문제는 클라이언트에서는 boardView 쿠키를 포함시켜 페칭하지만,  `getServerSideProps` 서버사이드에서 프리페칭 중엔 쿠키를 첨부하지 않고, api를 호출하면서 발생한 문제였습니다. 

```javascript
 const boardView = req.cookies['boardView'];

  if (boardView) headers = { ...headers, Cookie: `boardView=${boardView}` };
```

이렇게 직접 쿠키를 첨부시켜 문제 해결은 되었습니다. 
제휴/마켓/매거진 쪽도 조회수 중복 카운팅의 경우를 생각하고 qa 해결 진행하면 될 것 같습니다.

## Issue number and link

#89 
